### PR TITLE
Add missing ret instruction to vec-mixed_width_mask.S

### DIFF
--- a/benchmarks/vec-mixed_width_mask/vec-mixed_width_mask.S
+++ b/benchmarks/vec-mixed_width_mask/vec-mixed_width_mask.S
@@ -23,3 +23,4 @@ vec_mixed_width_mask:
   vse32.v v4, (a2) # Store b[i].
     add a2, a2, t1 # Bump pointer.
     bnez a0, vec_mixed_width_mask # Any more?
+  ret


### PR DESCRIPTION
### During testing, I found that the vec-mixed_width_mask test could not run correctly.
spike --isa=rv64gcbv vec-mixed_width_mask.riscv
*** FAILED *** (tohost = 1337)

I discovered that the issue was caused by the absence of the ret instruction in the vec-mixed_width_mask.S file. As a result, the function vec-mixed_width_mask could not return properly to the main function after execution, causing the test to fail.

![image](https://github.com/user-attachments/assets/b15c4cb1-d1a0-4ac0-92ea-70a5477d462b)
