### PR TITLE
Add vec-memcpy benchmark

### DIFF
--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -52,7 +52,8 @@ bmarks = \
 
 cpp_bmarks = \
 	vec-tasks \
-	vec-daxpy
+	vec-daxpy \
+	vec-memcpy
 
 #--------------------------------------------------------------------
 # Build rules

--- a/benchmarks/vec-memcpy/main.cc
+++ b/benchmarks/vec-memcpy/main.cc
@@ -1,0 +1,50 @@
+// vec-memcpy: RVV memcpy bandwidth benchmark.
+//
+// Kernel:  vendored in rvv_memcpy.h (see that file for its license).
+// Harness: adapted from vec-daxpy/main.cc
+//          (Axpy Kernel, Jesus Labarta, Barcelona Supercomputing Center).
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <riscv_vector.h>
+#include "util.h"
+#include "rvv_memcpy.h"
+
+// Logical memcpy size per run. Set above LLC size for DRAM bandwidth tests.
+// Tunable: -DCOPY_BYTES=<n>.
+#ifndef COPY_BYTES
+#define COPY_BYTES (1 << 22)  // 4 MiB
+#endif
+
+uint8_t src[COPY_BYTES];
+uint8_t dst[COPY_BYTES];
+
+int main(int argc, char *argv[])
+{
+  // warmup
+  memcpy_vec(dst, src, COPY_BYTES);
+
+  // Start instruction and cycles count of the region of interest
+  unsigned long cycles1, cycles2, instr2, instr1;
+  instr1 = read_csr(minstret);
+  cycles1 = read_csr(mcycle);
+
+  memcpy_vec(dst, src, COPY_BYTES);
+
+  asm volatile("fence");
+  // End instruction and cycles count of the region of interest
+  instr2 = read_csr(minstret);
+  cycles2 = read_csr(mcycle);
+
+  unsigned long cycles = cycles2 - cycles1;
+  unsigned long instrs = instr2 - instr1;
+  unsigned long traffic_bytes = 2UL * (unsigned long)COPY_BYTES;
+
+  printf("-CSR   NUMBER OF EXEC CYCLES :%lu\n", cycles);
+  printf("-CSR   NUMBER OF INSTRUCTIONS EXECUTED :%lu\n", instrs);
+  printf("-CSR   BYTES COPIED :%lu\n", (unsigned long)COPY_BYTES);
+  printf("-CSR   MEMORY TRAFFIC (BYTES, RD+WR) :%lu\n", traffic_bytes);
+
+  return 0;
+}

--- a/benchmarks/vec-memcpy/rvv_memcpy.h
+++ b/benchmarks/vec-memcpy/rvv_memcpy.h
@@ -1,0 +1,28 @@
+// RVV vectorized memcpy kernel.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+// (c) the riscv-rvv-intrinsic-doc contributors.
+// Vendored (logic verbatim) from riscv-non-isa/riscv-rvv-intrinsic-doc,
+// examples/rvv_memcpy.c @ e6bc0ae. Full license text in that repo's COPYING.BSD.
+//
+// C++ adaptations only: restrict -> __restrict__, explicit void* casts, static inline.
+
+#ifndef RVV_MEMCPY_H
+#define RVV_MEMCPY_H
+
+#include <riscv_vector.h>
+#include <stddef.h>
+
+static inline void *memcpy_vec(void *__restrict__ destination,
+                               const void *__restrict__ source, size_t n) {
+  unsigned char *dst = (unsigned char *)destination;
+  const unsigned char *src = (const unsigned char *)source;
+  for (size_t vl; n > 0; n -= vl, src += vl, dst += vl) {
+    vl = __riscv_vsetvl_e8m8(n);
+    vuint8m8_t vec_src = __riscv_vle8_v_u8m8(src, vl);
+    __riscv_vse8_v_u8m8(dst, vec_src, vl);
+  }
+  return destination;
+}
+
+#endif // RVV_MEMCPY_H


### PR DESCRIPTION
Adds a vectorized `memcpy` bandwidth benchmark to the benchmarks suite.

The benchmark runs an RVV byte copy and prints cycles and bytes so bandwidth can be computed. `COPY_BYTES` sets the copy size, defaults to 4 MiB, and can be varied to test different cache levels.

The copy kernel is vendored from [`riscv-rvv-intrinsic-doc`](https://github.com/riscv-non-isa/riscv-rvv-intrinsic-doc/blob/main/examples/rvv_memcpy.c) (BSD-3-Clause); see `rvv_memcpy.h`.