### PR TITLE
fix vdivu.vx/vremu.vx: zero-extend the scalar operand to its element width

### DIFF
--- a/src/main/scala/common/Parameters.scala
+++ b/src/main/scala/common/Parameters.scala
@@ -415,6 +415,10 @@ trait HasVectorParams extends HasVectorConsts { this: HasCoreParameters =>
     Cat(in((8 << eew)-1), in((8 << eew)-1,0)).asSInt
   })(in_eew)(64,0)
 
+  def zextElem(in: UInt, in_eew: UInt): UInt = VecInit.tabulate(4)( { eew =>
+    in((8 << eew)-1,0).pad(64)
+  })(in_eew)
+
   def extractElem(in: UInt, in_eew: UInt, eidx: UInt): UInt = {
     val bytes = in.asTypeOf(Vec(dLenB, UInt(8.W)))
     VecInit.tabulate(4) { eew =>

--- a/src/main/scala/exu/int/IntegerDivide.scala
+++ b/src/main/scala/exu/int/IntegerDivide.scala
@@ -73,12 +73,16 @@ class IterativeIntegerDivider(supportsMul: Boolean)(implicit p: Parameters) exte
   }
 
   div.io.req.bits.fn := ctrl_fn
+  // The unsigned operand must be zero-extended from its element width, not passed
+  // raw. For a .vx op the "element" is the full XLEN scalar, so passing it raw feeds
+  // the divide unit the whole scalar instead of its low SEW bits (a vdivu.vx / vremu.vx
+  // with a scalar whose bits above SEW are set then divides by the wrong, larger value).
   div.io.req.bits.in1 := Mux(ctrl_swapvdv2, io.iss.op.rvd_elem, Mux(ctrl_sign2,
     sextElem(io.iss.op.rvs2_elem, io.iss.op.rvs2_eew),
-    io.iss.op.rvs2_elem))
+    zextElem(io.iss.op.rvs2_elem, io.iss.op.rvs2_eew)))
   div.io.req.bits.in2 := Mux(ctrl_sign1,
     sextElem(io.iss.op.rvs1_elem, io.iss.op.rvs1_eew),
-    io.iss.op.rvs1_elem)
+    zextElem(io.iss.op.rvs1_elem, io.iss.op.rvs1_eew))
   div.io.req.bits.dw  := DW_64
   div.io.req.bits.tag := DontCare
 


### PR DESCRIPTION
Hello, here is a pull request for a bug I found.

vdivu.vx and vremu.vx do not truncate the .vx scalar operand to SEW before the
divide. In IntegerDivide.scala the unsigned operands are passed raw (rvs2_elem /
rvs1_elem), whereas the signed path sign-extends them from the element width. For
a .vx op the "element" is the full XLEN scalar, so passing it raw feeds the
64-bit divide unit the whole scalar. A vdivu.vx / vremu.vx whose scalar has bits
set above SEW then divides by the wrong, larger value, so the quotients come out
wrong (e.g. all zero).

The fix adds a zextElem helper (mirroring the existing sextElem) that
zero-extends an operand from its element width, and uses it for the unsigned
divide operands. The signed path is unchanged.

Found by differential testing against Spike; reduced reproducers (vdivu.vx at
SEW=8, seed 28020) diverge before the fix and match Spike after it.

Note: this was validated on the generated Verilog with the reproducers against Spike, not through a full Chisel elaboration (my Chipyard build ran out of JVM heap), so a run through the cosim tests before merging would be good.