### PR TITLE
fix .vf scalar: NaN-box a narrow scalar FP operand

### DIFF
--- a/src/main/scala/backend/ExecuteSequencer.scala
+++ b/src/main/scala/backend/ExecuteSequencer.scala
@@ -321,9 +321,23 @@ class ExecuteSequencer(supported_insns: Seq[VectorInstruction], maxPipeDepth: In
   io.iss.bits.slide_data := io.vgu.slide_data & slide_down_bit_mask
 
   io.iss.bits.use_scalar_rvs1 := inst.funct3.isOneOf(OPIVI, OPIVX, OPMVX, OPFVF) || rgather_v || rgatherei16
+  // NaN-box a narrow .vf scalar FP operand. When a scalar FP operand is read
+  // narrower than the FP register (vs1_eew < 64) and its upper bits are not all
+  // ones, RISC-V requires it to read as the canonical NaN of that width. Without
+  // this the FP units take the raw low bits, so a wider value held in the register
+  // but consumed by a narrower .vf op is used as a valid float instead of a NaN.
+  val fp_scalar = Wire(UInt(64.W))
+  fp_scalar := sscalar
+  when (inst.funct3 === OPFVF) {
+    when (vs1_eew === 2.U && !sscalar(63,32).andR) {
+      fp_scalar := Cat(sscalar(63,32), "h7FC00000".U(32.W))
+    } .elsewhen (vs1_eew === 1.U && !sscalar(63,16).andR) {
+      fp_scalar := Cat(sscalar(63,16), "h7E00".U(16.W))
+    }
+  }
   io.iss.bits.scalar := Mux(rgather_v || rgatherei16,
     rgather_eidx,
-    Mux(zext_imm5, uscalar, sscalar))
+    Mux(zext_imm5, uscalar, fp_scalar))
   io.iss.bits.use_zero_rvs2 := rgather_zero && (rgather || rgatherei16)
 
   io.iss.bits.acc       := inst.reduction && usesAcc.B


### PR DESCRIPTION
Hello, here is a pull request for a bug I found.

When a .vf scalar floating-point operand is read narrower than the FP register
(vs1_eew < 64) and its upper bits are not all ones, RISC-V requires it to read as
the canonical NaN of that width. Saturn passed the raw low bits, so a wider value
held in the register but consumed by a narrower .vf op (for example a double used
by a single-precision .vf) is treated as a valid float and produces a wrong
result.

The fix NaN-boxes the scalar at its source in ExecuteSequencer (0x7FC00000 for
e32, 0x7E00 for e16 when the upper bits are not all ones). Backend already splats
io.iss.bits.scalar into the per-lane operand the FP units read, so boxing this one
field covers every consumer. Non-.vf paths are unchanged.

Found by differential testing against Spike; the reduced reproducer
(vfwnmacc.vf with an unboxed scalar, seed 3217) diverges before and matches Spike
after.

Note: the defect was confirmed against Spike with the reproducer on the Saturn
version my fuzzer runs, and this is the same fix adapted to current master, where the
operand is still passed unboxed. I have not run a full Chisel build of the adapted
version (Saturn builds only through Chipyard), so a run through the cosim tests
before merging would be good.