### PR TITLE
fix vmulhu/vmulhsu/vwmulu.vx: truncate the .vx scalar operand to SEW

### DIFF
--- a/src/main/scala/exu/int/ElementwiseMultiplyPipe.scala
+++ b/src/main/scala/exu/int/ElementwiseMultiplyPipe.scala
@@ -23,8 +23,8 @@ class ElementwiseMultiplyPipe(depth: Int)(implicit p: Parameters) extends Pipeli
   val in_eew = io.pipe(0).bits.rvs1_eew
   val eidx = io.pipe(0).bits.eidx
 
-  val in_vs1 = Mux(ctrl.bool(MULSign1), sextElem(io.pipe(0).bits.rvs1_elem, in_eew), io.pipe(0).bits.rvs1_elem)
-  val in_vs2 = Mux(ctrl.bool(MULSign2), sextElem(io.pipe(0).bits.rvs2_elem, in_eew), io.pipe(0).bits.rvs2_elem)
+  val in_vs1 = Mux(ctrl.bool(MULSign1), sextElem(io.pipe(0).bits.rvs1_elem, in_eew), zextElem(io.pipe(0).bits.rvs1_elem, in_eew))
+  val in_vs2 = Mux(ctrl.bool(MULSign2), sextElem(io.pipe(0).bits.rvs2_elem, in_eew), zextElem(io.pipe(0).bits.rvs2_elem, in_eew))
   val in_vd  = io.pipe(0).bits.rvd_elem
 
   val prod = in_vs1.asSInt * Mux(ctrl.bool(MULSwapVdV2), in_vd, in_vs2).asSInt


### PR DESCRIPTION
Hello, here is a pull request for a bug I found.

vmulhu.vx, vmulhsu.vx and vwmulu.vx do not truncate the .vx scalar operand to SEW
before the multiply. In ElementwiseMultiplyPipe.scala the unsigned operands are
passed raw (rvs1_elem / rvs2_elem), whereas the signed path sign-extends them from
the element width. For a .vx op the "element" is the full XLEN scalar, so passing
it raw feeds the multiplier bits above SEW, and the op multiplies by
rs1[2*SEW-1:0] instead of rs1[SEW-1:0]. Plain vmul.vx hides it because the product
is truncated to SEW; vwmaccus.vx is affected too, since its scalar reaches the
second operand.

The fix uses zextElem (the helper added in #87) to zero-extend the unsigned
multiply operands, mirroring the existing sextElem on the signed path. For a .vv
element it is a no-op, so only the .vx scalar is truncated, and it covers both
operand lines (in_vs1 and in_vs2). This is the multiply-pipe counterpart of #87.

Found by differential testing against Spike; a reduced reproducer (vwmulu.vx at
SEW=8) diverges before the fix and matches Spike after it, and the unaffected ops
(vmulh.vx, vmul.vx, vwmaccsu.vx) are unchanged.