### PR TITLE
Advance the store segment buffer to the next row boundary (#96)

### DIFF
--- a/src/main/scala/mem/SegmentBuffer.scala
+++ b/src/main/scala/mem/SegmentBuffer.scala
@@ -225,7 +225,9 @@ class StoreSegmentBuffer(doubleBuffer: Boolean)(implicit p: Parameters) extends 
       out_sidx(out_sel) := out_segstart(out_sel)
       out_row := out_row + 1.U
     } .otherwise {
-      out_sidx(out_sel) := out_sidx(out_sel) + (cols.U >> out_eew(out_sel))
+      // advance to the next row boundary: sidx is row-aligned only when segstart is,
+      // and a segment resumed after a page split starts mid-row (see #96)
+      out_sidx(out_sel) := sidxOff(out_sidx(out_sel), out_eew(out_sel)) + (cols.U >> out_eew(out_sel))
     }
   }
 


### PR DESCRIPTION
Fixes #96.

One line in `StoreSegmentBuffer`. The output side walks the buffer in rows of `cols` fields and
advances by a fixed row's worth:

```scala
out_sidx(out_sel) := out_sidx(out_sel) + (cols.U >> out_eew(out_sel))
```

That is correct only while `sidx` is row-aligned, which holds whenever `segstart` is 0. A segment
**resumed after a page split** starts mid-row, so adding a whole row emits the partial row and then
steps clean over the remainder of the next one. In the reproducer on #96 that is fields 2–3 and 6–7
where 2..7 are owed — **16 bytes delivered against 24 requested, fields 4 and 5 never emitted**. The
store coalescing unit fills the shortfall from the push that is arriving, which belongs to the next
instruction, and the assertion in `Mem.scala` reports the resulting `debug_id` mismatch. Suppressing
that assertion does not make it benign: the store path livelocks.

The fix advances to the next **row boundary**:

```scala
out_sidx(out_sel) := sidxOff(out_sidx(out_sel), out_eew(out_sel)) + (cols.U >> out_eew(out_sel))
```

`sidxOff` already exists in this module and is used two lines above for the read index; it simply
was not used for the advance. **When `segstart` is 0 the two expressions are arithmetically
identical**, so every segment that is not split is bit-for-bit unchanged — which is the reason this
can be a one-liner rather than a new case.

### Verification

Two independent builds — chipyard 1.13 with Saturn `4ed795b` (assertion at `Mem.scala:348`) and a
dev tip at `d44530e` (`:383`):

| | firing offsets now clean | controls unchanged |
|---|---|---|
| 1.13.0 / `4ed795b` | 10 / 10 | 8 / 8 |
| dev tip / `d44530e` | 10 / 10 | 8 / 8 |

Confirming on the second revision is not ceremony: the two differ in this file's immediate
neighbourhood — `val cols = dLenB` against `val cols = mLenB` — so the patch context is not identical
between them.

Two scope checks, both clean, and each chosen because it could have failed:

* **`mLen=64`** — 9/9. This arm *passed before* the change and had to keep passing; it is how `mLen`
  was implicated in the first place, and a fix that broke it would have traded one defect for another.
* **Non-segment `vse32.v` stores** at the firing offsets and the control — clean. Provable from the
  source too, since `seg_nf == 0` never enqueues into the buffer, but three earlier diagnoses in this
  investigation died on arguments about the source, so it was measured.

An DSP kernel that never tripped the defect measures **23,553 cycles before the change and
23,553 after** — bit-identical, which is what a change that only alters which row index a *split*
segment emits next should do. Three other kernels that had been aborting now run to completion.

Two full-suite-scale runs carry this change — 1,533 vector tests, and a 3,133-ELF corpus at 3,042
pass — with no new failures in the store path. Those runs carried other local changes as well, so
they are evidence of no visible regression rather than a controlled A/B for this patch alone.
