### PR TITLE
vsmul: saturation bounds are 32-bit at SEW=64 (Scala Int overflow)

### DIFF
--- a/src/main/scala/common/Parameters.scala
+++ b/src/main/scala/common/Parameters.scala
@@ -433,8 +433,11 @@ trait HasVectorParams extends HasVectorConsts { this: HasCoreParameters =>
 
   def maxPosUInt(sew: Int) = Cat(0.U, ~(0.U(((8 << sew)-1).W)))
   def minNegUInt(sew: Int) = Cat(1.U,   0.U(((8 << sew)-1).W))
-  def maxPosSInt(sew: Int) = ((1 << ((8 << sew)-1))-1).S
-  def minNegSInt(sew: Int) = (-1 << ((8 << sew)-1)).S
+  // BigInt, not Int: Scala's Int is 32 bits and << masks the shift distance to 5 bits,
+  // so at sew=3 the distance 63 becomes 31 and both bounds come out 32-bit. The UInt
+  // pair above avoids this by building widths in Chisel rather than shifting in Scala.
+  def maxPosSInt(sew: Int) = ((BigInt(1) << ((8 << sew)-1))-1).S
+  def minNegSInt(sew: Int) = (-(BigInt(1) << ((8 << sew)-1))).S
   def maxPosFPUInt(sew: Int) = {
     val expBits = Seq(4, 5, 8, 11)(sew)
     val fracBits = (8 << sew) - expBits - 1

--- a/src/main/scala/exu/int/ElementwiseMultiplyPipe.scala
+++ b/src/main/scala/exu/int/ElementwiseMultiplyPipe.scala
@@ -44,8 +44,8 @@ class ElementwiseMultiplyPipe(depth: Int)(implicit p: Parameters) extends Pipeli
   val madd = Mux(ctrl_MULSub, ~lo, lo) + ctrl_MULSub + Mux(ctrl_MULSwapVdV2, in_vs2_pipe, in_vd_pipe)
   val rounding_incr = VecInit.tabulate(4)({ eew => RoundingIncrement(io.pipe(depth-2).bits.vxrm, prod_pipe((8 << eew)-1,0)) })(out_eew)
   val smul = VecInit.tabulate(4)({ eew => prod_pipe >> ((8 << eew) - 1) })(out_eew) + Cat(0.U(1.W), rounding_incr).asSInt
-  val smul_clip_neg = VecInit.tabulate(4)({ eew => (-1 << ((8 << eew)-1)).S })(out_eew)
-  val smul_clip_pos = VecInit.tabulate(4)({ eew => ((1 << ((8 << eew)-1)) - 1).S })(out_eew)
+  val smul_clip_neg = VecInit.tabulate(4)({ eew => (-(BigInt(1) << ((8 << eew)-1))).S })(out_eew)
+  val smul_clip_pos = VecInit.tabulate(4)({ eew => ((BigInt(1) << ((8 << eew)-1)) - 1).S })(out_eew)
   val smul_clip_hi = smul > smul_clip_pos
   val smul_clip_lo = smul < smul_clip_neg
   val smul_clipped = Mux(smul_clip_hi, smul_clip_pos, 0.S) | Mux(smul_clip_lo, smul_clip_neg, 0.S) | Mux(!smul_clip_hi && !smul_clip_lo, smul, 0.S)

--- a/src/main/scala/exu/int/IntegerDivide.scala
+++ b/src/main/scala/exu/int/IntegerDivide.scala
@@ -106,8 +106,8 @@ class IterativeIntegerDivider(supportsMul: Boolean)(implicit p: Parameters) exte
       op.rvs2_elem, op.rvd_elem)
     val rounding_incr = VecInit.tabulate(4)({ eew => RoundingIncrement(op.vxrm, prod((8 << eew)-1,0)) })(op.vd_eew)
     val smul = VecInit.tabulate(4)({ eew => prod >> ((8 << eew) - 1) })(op.vd_eew) + Cat(0.U(1.W), rounding_incr).asSInt
-    val smul_clip_neg = VecInit.tabulate(4)({ eew => (-1 << ((8 << eew)-1)).S })(op.vd_eew)
-    val smul_clip_pos = VecInit.tabulate(4)({ eew => ((1 << ((8 << eew)-1)) - 1).S })(op.vd_eew)
+    val smul_clip_neg = VecInit.tabulate(4)({ eew => (-(BigInt(1) << ((8 << eew)-1))).S })(op.vd_eew)
+    val smul_clip_pos = VecInit.tabulate(4)({ eew => ((BigInt(1) << ((8 << eew)-1)) - 1).S })(op.vd_eew)
     val smul_clip_hi = smul > smul_clip_pos
     val smul_clip_lo = smul < smul_clip_neg
     val smul_clipped = Mux(smul_clip_hi, smul_clip_pos, 0.S) | Mux(smul_clip_lo, smul_clip_neg, 0.S) | Mux(!smul_clip_hi && !smul_clip_lo, smul, 0.S)

--- a/src/main/scala/exu/int/SegmentedMultiplyPipe.scala
+++ b/src/main/scala/exu/int/SegmentedMultiplyPipe.scala
@@ -255,8 +255,12 @@ class VectorSMul(implicit p: Parameters) extends CoreModule()(p) with HasVectorP
       val rounding_incr = RoundingIncrement(io.vxrm, wideElem((8 << sew)-1, 0)) 
       (wideElem >> ((8 << sew) - 1)) + Cat(0.U(1.W), rounding_incr).asSInt  
     }
-    val clip_neg = (-1 << ((8 << sew)-1)).S 
-    val clip_pos = ((1 << ((8 << sew)-1)) - 1).S
+    // Scala's Int is 32 bits and << masks the shift distance to 5 bits, so at sew=3
+    // the distance 63 becomes 31 and both bounds come out 32-bit. BigInt makes the
+    // shift exact at every sew. sew=2 was correct only by accident: the Int overflow
+    // wraps to exactly the right value there.
+    val clip_neg = (-(BigInt(1) << ((8 << sew)-1))).S
+    val clip_pos = ((BigInt(1) << ((8 << sew)-1)) - 1).S
     val clip_hi = smul.map{ _ > clip_pos }
     val clip_lo = smul.map{ _ < clip_neg }    
     


### PR DESCRIPTION
Fixes the SEW=64 `vsmul` saturation bounds reported in #95.

`(-1 << ((8 << sew)-1)).S` and `((1 << ((8 << sew)-1)) - 1).S` are built with Scala `Int`
arithmetic. `Int` is 32 bits and `<<` masks the shift distance to 5 bits, so at `sew=3` the
distance 63 becomes 31 and both bounds come out ±2^31 instead of ±2^63.

Two wrong behaviours follow at SEW=64: a genuine saturation clips to `INT32_MAX` instead of
`INT64_MAX`, and a result merely *larger* than `INT32_MAX` is clipped although the spec does not
saturate it — raising `vxsat` when it should not.

**`sew=2` is correct only by accident**: `1 << 31` overflows to `Int.MinValue` and the `- 1`
wraps back to exactly `2147483647`. So checking "does SEW=32 work" gives the right answer for the
wrong reason, which is presumably how it survived review.

The same constant pair appears in four places and all four are fixed here, but only
`SegmentedMultiplyPipe` is instantiated by the config measured — the other three are the same
defect by inspection, not by measurement. `Parameters.scala`'s `maxPosSInt`/`minNegSInt` have no
call sites at all; they are worth taking because the adjacent *unsigned* helpers build their
widths in Chisel and are correct, so the broken idiom sits directly beneath the safe one under a
name a future caller would reach for.

Measured on `REFV256D128RocketConfig` at `c39102c`: `riscv-vector-tests` `vsmul_vv-4,5,6,7` and
`vsmul_vx-17,18,23,24` go 8/8 fail → 8/8 pass, and the multiply-family regression (`vmul`,
`vmulh{,u,su}`, `vwmul{,u,su}`, `vmacc`, `vnmsac`, `vmadd`, `vnmsub`, `vwmacc`) is 143/143.

A standalone reproducer will be attached below — prebuilt ELF, sources and disassembly. It reports
`bad=3` on stock `c39102c` and `bad=0` with this patch, same ELF both runs, and is clean on Spike
(`--isa=rv64gcv_zvl256b`) so the RTL results are an implementation difference rather than a
program error.
