### PR TITLE
Add zve64x config support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Saturn supports the entire RVV 1.0 application-profile specification, including
 
  * `V`-extension (Full application-profile V)
  * `Zve64d` - supports FP64, `ELEN`=64
+ * `Zve64x` - integer-only, no vector FP, `ELEN`=64
  * `Zvfh` - supports FP16
  * `Zvbb` - support basic vector bit manipulation
  * `Zvl64/128/256/512/1024` - configurable `VLEN`

--- a/chipyard/SaturnConfigs.scala
+++ b/chipyard/SaturnConfigs.scala
@@ -36,6 +36,14 @@ class REFV256D128RocketConfig extends Config(
   new freechips.rocketchip.rocket.WithNHugeCores(1) ++
   new chipyard.config.AbstractConfig)
 
+// Integer-only vector unit: reports Zve64x, and the scalar FPU is untouched. Mirrors
+// REFV256D128RocketConfig so the A/B is one variable.
+class INTV256D128RocketConfig extends Config(
+  new saturn.rocket.WithRocketVectorUnit(256, 128, VectorParams.refParams.copy(useVectorFP = false)) ++
+  new chipyard.config.WithSystemBusWidth(128) ++
+  new freechips.rocketchip.rocket.WithNHugeCores(1) ++
+  new chipyard.config.AbstractConfig)
+
 class REFV256D128M64RocketConfig extends Config(
   new saturn.rocket.WithRocketVectorUnit(256, 128, VectorParams.refParams, mLen = Some(64)) ++
   new freechips.rocketchip.rocket.WithNHugeCores(1) ++

--- a/src/main/scala/common/Parameters.scala
+++ b/src/main/scala/common/Parameters.scala
@@ -8,7 +8,7 @@ import freechips.rocketchip.util._
 import freechips.rocketchip.tile._
 import freechips.rocketchip.diplomacy.{BufferParams}
 import saturn.exu._
-import saturn.insns.{FUSel}
+import saturn.insns.{FUSel, F3}
 
 object VectorParams {
 
@@ -367,7 +367,14 @@ case class VectorParams(
 
   tlBuffer: BufferParams = BufferParams.default,
 ) {
-  def supported_ex_insns = issStructure.generate(this).map(_.insns).flatten
+  // OPFVV/OPFVF is the encoding space a Zve*x unit must not accept. Dropping the FP functional
+  // units removes most of it, but some FP-encoded instructions are hosted in integer ones.
+  def supported_ex_insns = {
+    val insns = issStructure.generate(this).map(_.insns).flatten
+    if (useVectorFP) insns else insns.filterNot { i =>
+      i.props.contains(F3(VectorConsts.OPFVV)) || i.props.contains(F3(VectorConsts.OPFVF))
+    }
+  }
 
   require(dLen >= 64, "dLen must be >= 64")
   require((dLen & (dLen - 1)) == 0, "dLen must be power of 2")

--- a/src/main/scala/common/Parameters.scala
+++ b/src/main/scala/common/Parameters.scala
@@ -162,9 +162,11 @@ object VXFunctionalUnitGroups {
     FPConvFactory
   )
 
-  def allFPFUs(fmaPipeDepth: Int, useScalarFPFMA: Boolean, elementwiseFP64: Boolean, segmentedFPFMA: Boolean) = (
-    (if (useScalarFPFMA) sharedFPFMA(fmaPipeDepth) else fpFMA(fmaPipeDepth, elementwiseFP64, segmentedFPFMA)) ++
-    fpMisc
+  def allFPFUs(fmaPipeDepth: Int, useScalarFPFMA: Boolean, elementwiseFP64: Boolean, segmentedFPFMA: Boolean, vectorFP: Boolean = true) = (
+    if (!vectorFP) Seq() else (
+      (if (useScalarFPFMA) sharedFPFMA(fmaPipeDepth) else fpFMA(fmaPipeDepth, elementwiseFP64, segmentedFPFMA)) ++
+      fpMisc
+    )
   )
 }
 
@@ -184,7 +186,7 @@ object VectorIssueStructure {
           VXSequencerParams("fp_int", (
             integerFUs(params.useIterativeIMul) ++
             (if (params.useIterativeIMul) Nil else integerMAC(params.imaPipeDepth, params.useSegmentedIMul)) ++
-            allFPFUs(params.fmaPipeDepth, params.useScalarFPFMA, params.useElementwiseFP64, params.useSegmentedFPFMA)
+            allFPFUs(params.fmaPipeDepth, params.useScalarFPFMA, params.useElementwiseFP64, params.useSegmentedFPFMA, params.useVectorFP)
           ))
         )
       )
@@ -200,7 +202,7 @@ object VectorIssueStructure {
         seqs = Seq(
           VXSequencerParams("int", integerFUs(params.useIterativeIMul)),
           VXSequencerParams("fp",
-            allFPFUs(params.fmaPipeDepth, params.useScalarFPFMA, params.useElementwiseFP64, params.useSegmentedFPFMA) ++
+            allFPFUs(params.fmaPipeDepth, params.useScalarFPFMA, params.useElementwiseFP64, params.useSegmentedFPFMA, params.useVectorFP) ++
             (if (params.useIterativeIMul) Nil else integerMAC(params.imaPipeDepth, params.useSegmentedIMul))
           )
         )
@@ -223,7 +225,7 @@ object VectorIssueStructure {
         depth = params.vxissqEntries,
         seqs = Seq(
           VXSequencerParams("fp",
-            allFPFUs(params.fmaPipeDepth, params.useScalarFPFMA, params.useElementwiseFP64, params.useSegmentedFPFMA) ++
+            allFPFUs(params.fmaPipeDepth, params.useScalarFPFMA, params.useElementwiseFP64, params.useSegmentedFPFMA, params.useVectorFP) ++
             (if (params.useIterativeIMul) Nil else integerMAC(params.imaPipeDepth, params.useSegmentedIMul))
           )
         )
@@ -235,6 +237,8 @@ object VectorIssueStructure {
   case object MultiFMA extends VectorIssueStructure {
     def generate(params: VectorParams) = {
       require(!params.useScalarFPFMA)
+      // The "fp1" sequencer calls fpFMA directly, so the allFPFUs guard does not reach it.
+      require(params.useVectorFP, "MultiFMA is incompatible with useVectorFP = false")
       val int_path = VXIssuePathParams(
         name = "int",
         depth = params.vxissqEntries,
@@ -247,7 +251,7 @@ object VectorIssueStructure {
         depth = params.vxissqEntries,
         seqs = Seq(
           VXSequencerParams("fp0",
-            allFPFUs(params.fmaPipeDepth, params.useScalarFPFMA, params.useElementwiseFP64, params.useSegmentedFPFMA) ++
+            allFPFUs(params.fmaPipeDepth, params.useScalarFPFMA, params.useElementwiseFP64, params.useSegmentedFPFMA, params.useVectorFP) ++
             (if (params.useIterativeIMul) Nil else integerMAC(params.imaPipeDepth, params.useSegmentedIMul))
           ),
           VXSequencerParams("fp1", fpFMA(params.fmaPipeDepth, params.useElementwiseFP64, params.useSegmentedFPFMA))
@@ -272,10 +276,12 @@ object VectorIssueStructure {
         name = "fp",
         depth = params.vxissqEntries,
         seqs = Seq(
-          VXSequencerParams("fp", allFPFUs(params.fmaPipeDepth, params.useScalarFPFMA, params.useElementwiseFP64, params.useSegmentedFPFMA))
+          VXSequencerParams("fp", allFPFUs(params.fmaPipeDepth, params.useScalarFPFMA, params.useElementwiseFP64, params.useSegmentedFPFMA, params.useVectorFP))
         )
       )
-      Seq(int_path, fp_path)
+      // Unlike Unified/Shared/Split, integerMAC does not share this sequencer, so without the FP
+      // units it would be empty and fail elaboration.
+      Seq(int_path) ++ (if (params.useVectorFP) Seq(fp_path) else Nil)
     }
   }
 
@@ -294,10 +300,12 @@ object VectorIssueStructure {
         name = "fp",
         depth = params.vxissqEntries,
         seqs = Seq(
-          VXSequencerParams("fp", allFPFUs(params.fmaPipeDepth, params.useScalarFPFMA, params.useElementwiseFP64, params.useSegmentedFPFMA))
+          VXSequencerParams("fp", allFPFUs(params.fmaPipeDepth, params.useScalarFPFMA, params.useElementwiseFP64, params.useSegmentedFPFMA, params.useVectorFP))
         )
       )
-      Seq(int_path, fp_path)
+      // Unlike Unified/Shared/Split, integerMAC does not share this sequencer, so without the FP
+      // units it would be empty and fail elaboration.
+      Seq(int_path) ++ (if (params.useVectorFP) Seq(fp_path) else Nil)
     }
   }
 }
@@ -331,6 +339,7 @@ case class VectorParams(
   vatSz: Int = 3,
 
   useSegmentedIMul: Boolean = false,
+  useVectorFP: Boolean = true,          // false builds an integer-only (Zve*x) vector unit
   useScalarFPFMA: Boolean = true,       // Use shared scalar FPU all non-FMA FP instructions
   useIterativeIMul: Boolean = false,
   useElementwiseFP64: Boolean = false,

--- a/src/main/scala/rocket/Configs.scala
+++ b/src/main/scala/rocket/Configs.scala
@@ -27,8 +27,9 @@ class WithRocketVectorUnit(
               case VectorParamsKey => params.copy(dLen=dLen, mLen=mLen.getOrElse(dLen))
             })),
             vLen = vLen,
-            vfLen = 64,
-            vfh = true,
+            // ISA string only; follow the hardware rather than claiming vector FP unconditionally.
+            vfLen = if (params.useVectorFP) 64 else 0,
+            vfh = params.useVectorFP,
             eLen = 64,
             vMemDataBits = if (useL1DCache) dLen else 0,
             decoder = ((p: Parameters) => {


### PR DESCRIPTION
## What this does

Adds a `VectorParams` field, `useVectorFP`, that removes the vector floating-point functional units,
so an integer-only (Zve64x) vector unit can be built from a config. **It defaults to true, so no
existing configuration changes behaviour** — `REFV256D128RocketConfig` elaborates byte-identically.

Mostly plumbing: there was no supported route to an FP-free vector unit, since `allFPFUs` is appended
unconditionally from six call sites, and `vfLen`/`vfh` fed only the ISA-string generator.

## Why integer-only at ELEN=64 specifically

Zve64x is a standard RVV embedded profile and integer-only vector suits DSP, fixed-point and crypto
workloads. The width is deliberate: **dropping vector float removes the last alternative to wide
integer accumulate.** For Q31-style fixed point an `i32→i64` widening multiply is the only *exact*
path — FP32's 24-bit mantissa cannot represent a Q31×Q31 product, so float was never a substitute
even when present. Remove float *and* cap intermediates at 32 bits and there is no exact multiply
left. `eLen` is untouched throughout.

By the same reasoning a Q15 workload would want Zve32x. We have not attempted it: `eLen` reaches
very little of the datapath today and `MultiplyBlock` hardcodes `xLen = 64`, so it looks like a
separate and larger piece of work.

## The commits

Four commits, intended as a set and in this order: 2 completes 1, and 3 and 4 build on both.

1. **`useVectorFP` guarding `allFPFUs`** — one guard, all six issue structures inherit it. Two need
   more: `MultiFMA` requires the field, because its `"fp1"` sequencer calls `fpFMA` directly rather
   than through `allFPFUs`, so an integer-only build would otherwise still contain an FP FMA; and
   `MultiALU`/`MultiMAC` drop their `fp_path`, because their `"fp"` sequencer holds `allFPFUs` alone
   — unlike `Unified`/`Shared`/`Split` where `integerMAC` shares it — and an empty sequencer fails
   elaboration in `ExecuteSequencer`.
2. **Drop the FP-encoded instructions hosted in integer FUs**, completing the first. Removing the
   FP units removes their instructions from decode, since `supported_ex_insns` is FU-derived — but
   five FP-encoded instructions live in *integer* FUs and are unaffected: `vfmerge.vfm`/
   `vfmv.v.f` in `IntegerPipe`, `vfmv.s.f`/`vfmv.f.s` in `MaskUnit`,
   `vfslide1up.vf`/`vfslide1down.vf` in `PermuteUnit`. Measured before this change, all five executed,
   and the three consuming a scalar FP operand returned a canonical NaN rather than faulting — silent
   wrong data. Filtered on OPFVV/OPFVF at `supported_ex_insns` rather than per-factory, so it catches
   any FP-encoded instruction wherever hosted; per-factory would need `IntegerPipeFactory` and
   `PermuteUnitFactory` converted from case objects and would only cover what is known today.
3. **Derive `vfLen`/`vfh` from the field**, so the reported extension follows the hardware instead of
   being an independent claim that happens to agree.
4. **`INTV256D128RocketConfig`**, mirroring `REFV256D128RocketConfig` so the A/B is one variable,
   plus a `Zve64x` line in the README's supported-profiles list.

## What is verified

* All six issue structures elaborate with the field false; `MultiMAC` emits no fp execution unit at
  all; `MultiFMA` fails its requirement as intended. With the default, output is unchanged.
* **RTL simulation on an integer-only build: all eleven vector-FP instructions tested now raise
  illegal-instruction, `mcause=2`, `mtval` carrying the instruction word** — `vfadd.vv`, `vfmul.vv`,
  `vfmacc.vv`, `vfdiv.vv`, `vmfeq.vv`, `vfcvt.x.f.v`, and the five listed above. As a control in the
  same run `vsetvli e32m1` sets `vl=8` and `vadd.vv` returns the expected result, so the vector unit
  is live and the traps are specific to FP encodings.
* ISA string: `rv64imafdcbv…zve64d_zvfh_zfh…` → `rv64imafdcb…zve64x_zfh…`. Loses `v` and `zvfh`,
  keeps `f`, `d`, `zfh` — the scalar FPU is untouched.

## Still to come

* **`riscv-vector-tests` with `INTEGER=1`** against an FP-capable control on identical binaries.
  Queued on machine time.
* **A standalone reproducer for the trap results** — the probe used above, generalised to assert
  rather than report and swept across SEW 8/16/32/64. Happy to shape it however suits, or to put it
  wherever you would want such a thing to live.
* **Spot-checks on real-world integer DSP kernels** — run on `INTV256D128RocketConfig` against
  `REFV256D128RocketConfig`, same binary on both, checking that the decode filter removed only FP
  encodings.

## One observation, not part of this change

`VectorIssueStructure` names a sequencer `"fp"`, and `integerMAC` is placed there too, so in an
integer-only build the generated `ExecutionUnitfp` contains only an integer multiplier. Confusing at
first, but harmless: a critical path ending in `vxufp/…/mul_out_pipe_b` reads as a floating-point product
when `fus_4` is `SegmentedMultiplyPipe`.

---

**Posted early for comment and correction of direction.**